### PR TITLE
Add simple API routes for customers, products, and jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+client/node_modules/
+server/node_modules/
+.DS_Store
+.env

--- a/server/index.js
+++ b/server/index.js
@@ -65,6 +65,58 @@ app.get('/api/test', (req, res) => {
   });
 });
 
+// In-memory sample data to satisfy front-end requests
+const customers = [
+  {
+    id: 1,
+    name: 'Sample Customer',
+    phone: '555-1234',
+    email: 'sample@example.com',
+    addresses: [{ address: '123 Main St', notes: '' }],
+    notes: '',
+    contractor: false
+  }
+];
+
+const products = [
+  {
+    id: 1,
+    name: 'Premium Mulch',
+    unit: 'yards',
+    retail_price: 45.0,
+    contractor_price: 40.5,
+    active: true
+  }
+];
+
+const jobs = [
+  {
+    id: 1,
+    customer_name: 'Sample Customer',
+    delivery_date: '2024-01-01',
+    status: 'scheduled',
+    paid: false
+  }
+];
+
+// Simple API endpoints returning sample data
+app.get('/api/customers', (req, res) => {
+  res.json({ customers });
+});
+
+app.get('/api/products', (req, res) => {
+  res.json({ products });
+});
+
+app.get('/api/jobs', (req, res) => {
+  const { date } = req.query;
+  let result = jobs;
+  if (date) {
+    result = jobs.filter(job => job.delivery_date === date);
+  }
+  res.json({ jobs: result });
+});
+
 app.listen(PORT, () => {
   console.log('=== NEW SIMPLE SERVER RUNNING ON PORT', PORT, '===');
 });


### PR DESCRIPTION
## Summary
- add in-memory sample data for customers, products, and jobs
- expose `/api/customers`, `/api/products`, and `/api/jobs` endpoints returning that data
- add `.gitignore` for node modules and environment files

## Testing
- `curl -i http://localhost:10000/api/customers`
- `curl -i http://localhost:10000/api/products`
- `curl -i http://localhost:10000/api/jobs`


------
https://chatgpt.com/codex/tasks/task_e_68ba5e7950808330945b354820b5cf06