### PR TITLE
Add in-memory customer creation endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -78,6 +78,9 @@ const customers = [
   }
 ];
 
+// Track next customer ID for in-memory operations
+let nextCustomerId = customers.length + 1;
+
 const products = [
   {
     id: 1,
@@ -121,6 +124,29 @@ app.get('/api/customers/search', (req, res) => {
   );
 
   res.json({ customers: filtered });
+});
+
+// Create new customer
+app.post('/api/customers', (req, res) => {
+  const { name, phone, email, addresses, notes, contractor = false } = req.body;
+
+  // Basic validation similar to full API
+  if (!name || !addresses || !Array.isArray(addresses) || addresses.length === 0) {
+    return res.status(400).json({ message: 'Name and at least one address are required' });
+  }
+
+  const newCustomer = {
+    id: nextCustomerId++,
+    name,
+    phone: phone || null,
+    email: email || null,
+    addresses,
+    notes: notes || '',
+    contractor: Boolean(contractor)
+  };
+
+  customers.push(newCustomer);
+  res.status(201).json({ message: 'Customer created successfully', customer: newCustomer });
 });
 
 app.get('/api/products', (req, res) => {


### PR DESCRIPTION
## Summary
- Track next customer id in server and expose POST /api/customers endpoint
- Validate input and return new customer data on creation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `curl -i -X POST http://localhost:10000/api/customers -H 'Content-Type: application/json' -d '{"name":"John","addresses":[{"address":"123 Main"}]}'`
- `curl -i -X POST http://localhost:10000/api/products -H 'Content-Type: application/json' -d '{"name":"Prod","unit":"yards"}'`


------
https://chatgpt.com/codex/tasks/task_e_68bae75a4268833080124493a4ad31a8