### PR TITLE
Fix mobile footer layout for contact info

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -199,13 +199,13 @@ const Dashboard = () => {
 
       {/* East Meadow Nursery Info */}
       <div className="mt-8 bg-gradient-to-r from-eastmeadow-50 to-green-50 border border-eastmeadow-200 rounded-lg p-6">
-        <div className="flex items-center justify-between">
-          <div>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="text-center sm:text-left">
             <h3 className="text-lg font-semibold text-eastmeadow-900">East Meadow Nursery</h3>
             <p className="text-eastmeadow-700">Professional Landscape Supply & Delivery</p>
           </div>
-          <div className="text-right">
-            <div className="text-2xl font-bold text-eastmeadow-900">413-566-TREE</div>
+          <div className="text-center sm:text-right">
+            <div className="text-2xl font-bold text-eastmeadow-900 whitespace-nowrap">413-566-TREE</div>
             <div className="text-sm text-eastmeadow-600">Western Massachusetts</div>
           </div>
         </div>

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -321,14 +321,14 @@ const Profile = () => {
 
         {/* East Meadow Nursery Info */}
         <div className="bg-eastmeadow-50 border border-eastmeadow-200 rounded-lg p-6">
-          <div className="flex items-center justify-between">
-            <div>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="text-center sm:text-left">
               <h3 className="text-lg font-semibold text-eastmeadow-900">East Meadow Nursery</h3>
               <p className="text-eastmeadow-700">Professional Landscape Supply & Delivery</p>
               <p className="text-sm text-eastmeadow-600 mt-1">Western Massachusetts</p>
             </div>
-            <div className="text-right">
-              <div className="text-2xl font-bold text-eastmeadow-900">413-566-TREE</div>
+            <div className="text-center sm:text-right">
+              <div className="text-2xl font-bold text-eastmeadow-900 whitespace-nowrap">413-566-TREE</div>
               <div className="text-sm text-eastmeadow-600">Call for Support</div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- make footer contact section responsive on small screens
- prevent phone number from breaking across lines

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd client && npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `cd client && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb514c21a4833098e54e0a04278564