### PR TITLE
Fix boolean insert for jobs creation

### DIFF
--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -329,7 +329,9 @@ router.post('/', auth, requireOfficeOrAdmin, async (req, res) => {
     }
 
     // Create parameterized query
-    const placeholders = insertValues.map((_, index) => `${index + 1}`).join(', ');
+    const placeholders = insertValues
+      .map((_, index) => `$${index + 1}`)
+      .join(', ');
     const insertQuery = `
       INSERT INTO jobs (${insertFields.join(', ')})
       VALUES (${placeholders})


### PR DESCRIPTION
## Summary
- correct SQL parameter placeholder generation in job creation route

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb525ca1748330b347940c68993a79