### PR TITLE
Align application with Eastern Time

### DIFF
--- a/client/src/components/JobDetailModal.jsx
+++ b/client/src/components/JobDetailModal.jsx
@@ -314,7 +314,8 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
                       weekday: 'short',
                       month: 'short',
                       day: 'numeric',
-                      year: 'numeric'
+                      year: 'numeric',
+                      timeZone: 'America/New_York'
                     }) || 'Date not set'}
                   </span>
                 </div>

--- a/client/src/pages/Customers.jsx
+++ b/client/src/pages/Customers.jsx
@@ -424,7 +424,7 @@ const Customers = () => {
 
                       <div className="flex items-center gap-2 text-sm text-gray-600">
                         <Calendar className="h-4 w-4" />
-                        <span>Customer since {new Date(customer.created_at).toLocaleDateString()}</span>
+                        <span>Customer since {new Date(customer.created_at).toLocaleDateString('en-US', { timeZone: 'America/New_York' })}</span>
                       </div>
 
                       <div className="flex items-center gap-2 text-sm text-gray-600">

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -168,7 +168,7 @@ const Dashboard = () => {
                   <div className="flex-1">
                     <p className="font-medium text-gray-900">{job.customer_name}</p>
                     <p className="text-sm text-gray-600">
-                      {new Date(job.delivery_date).toLocaleDateString()}
+                      {new Date(job.delivery_date).toLocaleDateString('en-US', { timeZone: 'America/New_York' })}
                     </p>
                   </div>
                   <div className="flex items-center gap-2">

--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -205,7 +205,7 @@ const Jobs = () => {
       days.push({
         date: dateStr,
         displayDate: date.getDate(),
-        displayDay: date.toLocaleDateString('en-US', { weekday: 'short' }),
+        displayDay: date.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'America/New_York' }),
         isToday: dateStr === new Date().toISOString().split('T')[0],
         jobCount: dayJobs.length,
         completedCount: dayJobs.filter(job => job.status === 'completed').length
@@ -299,11 +299,12 @@ const Jobs = () => {
               Today's Deliveries ({todaysJobs.length})
             </h2>
             <p className="text-sm text-blue-700 mt-1">
-              {new Date().toLocaleDateString('en-US', { 
-                weekday: 'long', 
-                year: 'numeric', 
-                month: 'long', 
-                day: 'numeric' 
+              {new Date().toLocaleDateString('en-US', {
+                weekday: 'long',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                timeZone: 'America/New_York'
               })}
             </p>
           </div>
@@ -510,11 +511,12 @@ const Jobs = () => {
             {showToBeScheduled ? (
               `Orders To Be Scheduled (${filteredJobs.length})`
             ) : (
-              `Deliveries for ${new Date(selectedDate + 'T00:00:00').toLocaleDateString('en-US', { 
-                weekday: 'long', 
-                year: 'numeric', 
-                month: 'long', 
-                day: 'numeric' 
+              `Deliveries for ${new Date(selectedDate + 'T00:00:00').toLocaleDateString('en-US', {
+                weekday: 'long',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                timeZone: 'America/New_York'
               })}`
             )}
           </h3>
@@ -639,7 +641,8 @@ const DriverJobCard = ({ job, onClick, drivers, getDriverName, formatDate, showD
                 {formatDate(job.delivery_date)?.toLocaleDateString('en-US', {
                   weekday: 'short',
                   month: 'short',
-                  day: 'numeric'
+                  day: 'numeric',
+                  timeZone: 'America/New_York'
                 }) || 'Invalid Date'}
               </span>
             </div>
@@ -789,7 +792,8 @@ const MobileJobCard = ({ job, onClick, onUpdateSchedule, isOffice, showSchedulin
                       {formatDate(job.delivery_date)?.toLocaleDateString('en-US', {
                         weekday: 'short',
                         month: 'short',
-                        day: 'numeric'
+                        day: 'numeric',
+                        timeZone: 'America/New_York'
                       }) || 'Invalid Date'}
                     </span>
                   </div>

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -298,7 +298,8 @@ const Profile = () => {
                 {user?.created_at ? new Date(user.created_at).toLocaleDateString('en-US', {
                   year: 'numeric',
                   month: 'long',
-                  day: 'numeric'
+                  day: 'numeric',
+                  timeZone: 'America/New_York'
                 }) : 'Unknown'}
               </span>
             </div>
@@ -312,7 +313,8 @@ const Profile = () => {
                 {user?.updated_at ? new Date(user.updated_at).toLocaleDateString('en-US', {
                   year: 'numeric',
                   month: 'long',
-                  day: 'numeric'
+                  day: 'numeric',
+                  timeZone: 'America/New_York'
                 }) : 'Never'}
               </span>
             </div>

--- a/client/src/pages/Users.jsx
+++ b/client/src/pages/Users.jsx
@@ -383,7 +383,8 @@ const Users = () => {
                       {new Date(user.created_at).toLocaleDateString('en-US', {
                         year: 'numeric',
                         month: 'short',
-                        day: 'numeric'
+                        day: 'numeric',
+                        timeZone: 'America/New_York'
                       })}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -8,6 +8,11 @@ const pool = new Pool({
   connectionTimeoutMillis: 2000,
 });
 
+// Ensure all database connections operate in Eastern Time
+pool.on('connect', (client) => {
+  client.query("SET TIME ZONE 'America/New_York'");
+});
+
 // Database initialization and migration
 const initialize = async () => {
   try {

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,8 @@
 console.log('=== EAST MEADOW NURSERY DATABASE SERVER STARTING ===');
 
+// Ensure the Node process uses Eastern Time for all date handling
+process.env.TZ = 'America/New_York';
+
 const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -120,6 +120,9 @@ router.get('/', auth, async (req, res) => {
     // For now, return jobs without products to simplify
     const jobs = result.rows.map(job => ({
       ...job,
+      delivery_date: job.delivery_date
+        ? new Date(job.delivery_date).toISOString().split('T')[0]
+        : null,
       products: [] // Empty products array for now
     }));
 
@@ -346,9 +349,12 @@ router.post('/', auth, requireOfficeOrAdmin, async (req, res) => {
     const job = result.rows[0];
     console.log('Job created successfully:', job.id);
 
-    // Add empty products array for response
+    // Add empty products array for response and normalize date
     const responseJob = {
       ...job,
+      delivery_date: job.delivery_date
+        ? new Date(job.delivery_date).toISOString().split('T')[0]
+        : null,
       products: []
     };
 
@@ -495,6 +501,9 @@ router.put('/:id', auth, async (req, res) => {
 
     const responseJob = {
       ...result.rows[0],
+      delivery_date: result.rows[0].delivery_date
+        ? new Date(result.rows[0].delivery_date).toISOString().split('T')[0]
+        : null,
       products: []
     };
 


### PR DESCRIPTION
## Summary
- set Node and PostgreSQL connections to America/New_York
- normalize job delivery dates returned by the API
- render all dates in frontend using Eastern Time

## Testing
- `node --check server/index.js`
- `node --check server/config/database.js`
- `node --check server/routes/jobs.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb53dcf61883309e307712bcd4dc5f