### PR TITLE
Fix paid status miscalculation

### DIFF
--- a/client/src/components/JobDetailModal.jsx
+++ b/client/src/components/JobDetailModal.jsx
@@ -61,8 +61,8 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
   // Calculate total amount due
   const totalDue = job.total_amount || 0;
   const alreadyPaid = job.payment_received || 0;
-  const amountDue = Math.max(0, totalDue - alreadyPaid);
-  const isFullyPaid = amountDue <= 0;
+  const amountDue = job.paid ? 0 : Math.max(0, totalDue - alreadyPaid);
+  const isFullyPaid = job.paid || (totalDue > 0 && alreadyPaid >= totalDue);
   const isPartiallyPaid = !isFullyPaid && alreadyPaid > 0;
 
   const handleEditChange = (field, value) => {

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -39,7 +39,8 @@ const Dashboard = () => {
         pendingPayments: allJobs.filter(job => {
           const total = job.total_amount || 0;
           const received = job.payment_received || 0;
-          return job.status === 'completed' && total > 0 && received < total;
+          const isPaid = job.paid || (total > 0 && received >= total);
+          return job.status === 'completed' && !isPaid;
         }).length
       });
 

--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -248,7 +248,7 @@ const Jobs = () => {
   const unpaidJobs = jobs.filter(job => {
     const total = job.total_amount || 0;
     const received = job.payment_received || 0;
-    const isPaid = total === 0 || received >= total;
+    const isPaid = job.paid || (total > 0 && received >= total);
     if (user?.role === 'driver') {
       return !isPaid && job.assigned_driver === user.userId && job.status !== 'to_be_scheduled';
     }
@@ -651,8 +651,8 @@ const DriverJobCard = ({ job, onClick, drivers, getDriverName, formatDate, showD
   // Calculate payment status
   const totalDue = job.total_amount || 0;
   const alreadyPaid = job.payment_received || 0;
-  const amountDue = Math.max(0, totalDue - alreadyPaid);
-  const isFullyPaid = amountDue <= 0;
+  const amountDue = job.paid ? 0 : Math.max(0, totalDue - alreadyPaid);
+  const isFullyPaid = job.paid || (totalDue > 0 && alreadyPaid >= totalDue);
   const isPartiallyPaid = !isFullyPaid && alreadyPaid > 0;
 
   return (
@@ -756,8 +756,8 @@ const MobileJobCard = ({ job, onClick, onUpdateSchedule, isOffice, showSchedulin
   // Calculate payment status
   const totalDue = job.total_amount || 0;
   const alreadyPaid = job.payment_received || 0;
-  const amountDue = Math.max(0, totalDue - alreadyPaid);
-  const isFullyPaid = amountDue <= 0;
+  const amountDue = job.paid ? 0 : Math.max(0, totalDue - alreadyPaid);
+  const isFullyPaid = job.paid || (totalDue > 0 && alreadyPaid >= totalDue);
   const isPartiallyPaid = !isFullyPaid && alreadyPaid > 0;
   const isToBeScheduled = job.status === 'to_be_scheduled' || !job.delivery_date;
 

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -472,12 +472,17 @@ router.put('/:id', auth, async (req, res) => {
       }
     }
 
-    // Always recalculate paid status based on payments
-    const paymentReceived = req.body.payment_received !== undefined
-      ? parseFloat(req.body.payment_received)
-      : job.payment_received || 0;
-    const totalAmount = job.total_amount || 0;
-    const paidStatus = totalAmount > 0 && paymentReceived >= totalAmount;
+    // Determine paid status
+    let paidStatus;
+    if (req.body.paid !== undefined) {
+      paidStatus = req.body.paid === true;
+    } else {
+      const paymentReceived = req.body.payment_received !== undefined
+        ? parseFloat(req.body.payment_received)
+        : job.payment_received || 0;
+      const totalAmount = job.total_amount || 0;
+      paidStatus = totalAmount > 0 && paymentReceived >= totalAmount;
+    }
 
     if (availableColumns.includes('paid')) {
       paramCount++;


### PR DESCRIPTION
## Summary
- Honor `paid` flag when counting and displaying payment status in job cards and dashboard
- Allow manual override of paid status in job update route

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb5a811f80833099be0a6fb872e99a