### PR TITLE
fix: ensure dashboard shows driver deliveries

### DIFF
--- a/client/src/pages/AddJob.jsx
+++ b/client/src/pages/AddJob.jsx
@@ -6,6 +6,9 @@ import toast from 'react-hot-toast';
 import LoadingSpinner from '../components/LoadingSpinner';
 import CustomerSearch from '../components/CustomerSearch';
 
+// Consistently use Eastern Time for date handling
+const LOCAL_TIME_ZONE = 'America/New_York';
+
 const AddJob = () => {
   const navigate = useNavigate();
   const { isOffice, makeAuthenticatedRequest } = useAuth();
@@ -20,7 +23,8 @@ const AddJob = () => {
     customer_name: '',
     customer_phone: '',
     address: '',
-    delivery_date: new Date().toISOString().split('T')[0],
+    // Default to today's date in Eastern Time
+    delivery_date: new Date().toLocaleDateString('en-CA', { timeZone: LOCAL_TIME_ZONE }),
     special_instructions: '',
     paid: false,
     assigned_driver: '',

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -4,6 +4,9 @@ import { useAuth } from '../contexts/AuthContext';
 import { Calendar, Package, Users, TrendingUp, Clock, CheckCircle } from 'lucide-react';
 import LoadingSpinner from '../components/LoadingSpinner';
 
+// Ensure dates are handled in Eastern Time to avoid timezone-related issues
+const LOCAL_TIME_ZONE = 'America/New_York';
+
 const Dashboard = () => {
   const { user, isOffice, makeAuthenticatedRequest } = useAuth();
   const [stats, setStats] = useState({
@@ -21,7 +24,8 @@ const Dashboard = () => {
 
   const fetchDashboardData = async () => {
     try {
-      const today = new Date().toISOString().split('T')[0];
+      // Get today's date in YYYY-MM-DD format using Eastern Time
+      const today = new Date().toLocaleDateString('en-CA', { timeZone: LOCAL_TIME_ZONE });
       
       // Use makeAuthenticatedRequest instead of regular axios
       const [jobsResponse, todayJobsResponse] = await Promise.all([


### PR DESCRIPTION
## Summary
- ensure dashboard uses Eastern Time to count today's deliveries
- default new jobs to Eastern Time date

## Testing
- `npm test` (fails: Missing script: "test")
- `cd client && npm test` (fails: Missing script: "test")
- `cd client && npm run lint` (fails: ESLint couldn't find a configuration file)
- `cd server && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68bb5b15d16483308680f60ab2433803