### PR TITLE
Enhance job status tags and ordering

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -57,23 +57,23 @@
   }
 
   .status-badge {
-    @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium;
+    @apply inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold border;
   }
 
   .status-scheduled {
-    @apply status-badge bg-yellow-100 text-yellow-800;
+    @apply status-badge bg-yellow-200 text-yellow-800 border-yellow-400;
   }
 
   .status-in-progress {
-    @apply status-badge bg-blue-100 text-blue-800;
+    @apply status-badge bg-blue-100 text-blue-800 border-blue-300;
   }
 
   .status-completed {
-    @apply status-badge bg-green-100 text-green-800;
+    @apply status-badge bg-green-200 text-green-800 border-green-500;
   }
 
   .status-cancelled {
-    @apply status-badge bg-red-100 text-red-800;
+    @apply status-badge bg-red-100 text-red-800 border-red-300;
   }
 
   .payment-paid {

--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -162,6 +162,14 @@ const Jobs = () => {
       filtered = filtered.filter(job => job.status === statusFilter);
     }
 
+    // Place completed jobs at the bottom of the list for easier scanning
+    filtered = filtered.sort((a, b) => {
+      const aCompleted = a.status === 'completed';
+      const bCompleted = b.status === 'completed';
+      if (aCompleted === bCompleted) return 0;
+      return aCompleted ? 1 : -1;
+    });
+
     setFilteredJobs(filtered);
   };
 
@@ -735,7 +743,9 @@ const DriverJobCard = ({ job, onClick, drivers, getDriverName, formatDate, showD
 
         {/* Status and arrow */}
         <div className="flex items-center gap-2 flex-shrink-0 ml-4">
-          <span className={`status-${job.status} text-xs`}>
+          <span className={`status-${job.status}`}>
+            {job.status === 'scheduled' && <Clock className="h-3 w-3" />}
+            {job.status === 'completed' && <CheckCircle className="h-3 w-3" />}
             {job.status.replace('_', ' ').toUpperCase()}
           </span>
           <ChevronRight className="h-5 w-5 text-gray-400" />
@@ -804,7 +814,9 @@ const MobileJobCard = ({ job, onClick, onUpdateSchedule, isOffice, showSchedulin
                     To Schedule
                   </span>
                 ) : (
-                  <span className={`status-${job.status} text-xs`}>
+                  <span className={`status-${job.status}`}>
+                    {job.status === 'scheduled' && <Clock className="h-3 w-3" />}
+                    {job.status === 'completed' && <CheckCircle className="h-3 w-3" />}
                     {job.status.replace('_', ' ').toUpperCase()}
                   </span>
                 )}


### PR DESCRIPTION
## Summary
- make job status badges more prominent with borders and icons
- sort completed jobs to bottom of the list for easier scanning

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68bb5beb0ff08330bf7b4eeebfde52fc