### PR TITLE
Fix driver delivery view and calendar date focus

### DIFF
--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -25,7 +25,7 @@ const LOCAL_TIME_ZONE = 'America/New_York';
 
 // Returns current date in YYYY-MM-DD format for the configured timezone
 const getTodayDate = () =>
-  new Date().toLocaleDateString('en-CA', { timeZone: LOCAL_TIME_ZONE });
+  new Intl.DateTimeFormat('en-CA', { timeZone: LOCAL_TIME_ZONE }).format(new Date());
 
 const Jobs = () => {
   const { isOffice, user, makeAuthenticatedRequest } = useAuth();
@@ -40,6 +40,11 @@ const Jobs = () => {
   const [selectedJob, setSelectedJob] = useState(null);
   const [showJobModal, setShowJobModal] = useState(false);
   const weekScrollRef = useRef(null);
+
+  // Ensure calendar starts on the current day
+  useEffect(() => {
+    setSelectedDate(getTodayDate());
+  }, []);
 
   // Helper function to safely format dates
   const formatDate = (dateString) => {
@@ -100,9 +105,10 @@ const Jobs = () => {
   useEffect(() => {
     if (user?.role === 'driver' && weekScrollRef.current) {
       const selectedButton = weekScrollRef.current.querySelector('[data-selected="true"]');
-      selectedButton?.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+      selectedButton?.scrollIntoView({ inline: 'center', block: 'nearest' });
     }
-  }, [selectedDate, user]);
+    // Include loading so scroll happens after jobs are fetched
+  }, [selectedDate, user, loading]);
 
   const fetchDrivers = async () => {
     try {

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -217,6 +217,10 @@ router.get('/', auth, async (req, res) => {
 
     const jobs = result.rows.map(job => ({
       ...job,
+      id: job.id ? parseInt(job.id) : job.id,
+      assigned_driver: job.assigned_driver ? parseInt(job.assigned_driver) : null,
+      total_amount: job.total_amount ? parseFloat(job.total_amount) : 0,
+      payment_received: job.payment_received ? parseFloat(job.payment_received) : 0,
       delivery_date: job.delivery_date
         ? new Date(job.delivery_date).toISOString().split('T')[0]
         : null,
@@ -275,6 +279,10 @@ router.get('/:id', auth, async (req, res) => {
 
     const jobWithProducts = {
       ...job,
+      id: job.id ? parseInt(job.id) : job.id,
+      assigned_driver: job.assigned_driver ? parseInt(job.assigned_driver) : null,
+      total_amount: job.total_amount ? parseFloat(job.total_amount) : 0,
+      payment_received: job.payment_received ? parseFloat(job.payment_received) : 0,
       delivery_date: job.delivery_date
         ? new Date(job.delivery_date).toISOString().split('T')[0]
         : null,


### PR DESCRIPTION
## Summary
- Ensure numeric job fields like `assigned_driver` are returned as numbers so drivers see their deliveries
- Initialize calendar to today's date and scroll the week view to the selected day for drivers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd server && npm test` *(fails: Missing script: "test")*
- `cd client && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb7c16d5dc8330ac75a0a595cd362e