### PR TITLE
fix: parse payment values to avoid partial job crash

### DIFF
--- a/client/src/components/JobDetailModal.jsx
+++ b/client/src/components/JobDetailModal.jsx
@@ -60,8 +60,9 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
   };
 
   // Calculate total amount due
-  const totalDue = job.total_amount || 0;
-  const alreadyPaid = job.payment_received || 0;
+  // Ensure numeric values to prevent toFixed errors when API returns strings
+  const totalDue = parseFloat(job.total_amount) || 0;
+  const alreadyPaid = parseFloat(job.payment_received) || 0;
   const amountDue = job.paid ? 0 : Math.max(0, totalDue - alreadyPaid);
   const isFullyPaid = job.paid || (totalDue > 0 && alreadyPaid >= totalDue);
   const isPartiallyPaid = !isFullyPaid && alreadyPaid > 0;

--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -666,8 +666,8 @@ const Jobs = () => {
 // Driver-optimized job card
 const DriverJobCard = ({ job, onClick, drivers, getDriverName, formatDate, showDate = false }) => {
   // Calculate payment status
-  const totalDue = job.total_amount || 0;
-  const alreadyPaid = job.payment_received || 0;
+  const totalDue = parseFloat(job.total_amount) || 0;
+  const alreadyPaid = parseFloat(job.payment_received) || 0;
   const amountDue = job.paid ? 0 : Math.max(0, totalDue - alreadyPaid);
   const isFullyPaid = job.paid || (totalDue > 0 && alreadyPaid >= totalDue);
   const isPartiallyPaid = !isFullyPaid && alreadyPaid > 0;
@@ -773,8 +773,8 @@ const MobileJobCard = ({ job, onClick, onUpdateSchedule, isOffice, showSchedulin
   });
 
   // Calculate payment status
-  const totalDue = job.total_amount || 0;
-  const alreadyPaid = job.payment_received || 0;
+  const totalDue = parseFloat(job.total_amount) || 0;
+  const alreadyPaid = parseFloat(job.payment_received) || 0;
   const amountDue = job.paid ? 0 : Math.max(0, totalDue - alreadyPaid);
   const isFullyPaid = job.paid || (totalDue > 0 && alreadyPaid >= totalDue);
   const isPartiallyPaid = !isFullyPaid && alreadyPaid > 0;


### PR DESCRIPTION
## Summary
- ensure job payment fields are treated as numbers before formatting
- avoid runtime error when viewing partially paid jobs by parsing totals and amounts paid

## Testing
- `npm test` (fails: Missing script "test")
- `(cd server && npm test)` (fails: Missing script "test")
- `(cd client && npm test)` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bb7d5e05e48330b55bcd5acb193aa7