### PR TITLE
Allow admin and office to complete jobs, prune unused statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ nursery-delivery-scheduler/
 - `delivery_date` - Scheduled delivery date
 - `special_instructions` - Delivery notes
 - `paid` - Payment status
-- `status` - Job status (scheduled/in_progress/completed/cancelled)
+- `status` - Job status (scheduled/completed/to_be_scheduled)
 - `driver_notes` - Driver completion notes
 - `payment_received` - Amount collected by driver
 - `created_by` - Office user who created the job

--- a/client/src/components/JobDetailModal.jsx
+++ b/client/src/components/JobDetailModal.jsx
@@ -367,8 +367,8 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
             </div>
           </div>
 
-          {/* Driver Actions - Complete Delivery */}
-          {user?.role === 'driver' && job.status === 'scheduled' && job.assigned_driver === user.userId && (
+          {/* Complete Delivery Actions */}
+          {job.status === 'scheduled' && ((user?.role === 'driver' && job.assigned_driver === user.userId) || isOffice || isAdmin) && (
             <div className="space-y-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
               <h3 className="font-medium text-blue-900">Complete Delivery</h3>
               

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -64,16 +64,8 @@
     @apply status-badge bg-indigo-100 text-indigo-800 border-indigo-300;
   }
 
-  .status-in-progress {
-    @apply status-badge bg-blue-100 text-blue-800 border-blue-300;
-  }
-
   .status-completed {
     @apply status-badge bg-green-200 text-green-800 border-green-500;
-  }
-
-  .status-cancelled {
-    @apply status-badge bg-red-100 text-red-800 border-red-300;
   }
 
   .payment-paid {

--- a/client/src/pages/EditJob.jsx
+++ b/client/src/pages/EditJob.jsx
@@ -291,9 +291,7 @@ const EditJob = () => {
                     className="input-field"
                   >
                     <option value="scheduled">Scheduled</option>
-                    <option value="in_progress">In Progress</option>
                     <option value="completed">Completed</option>
-                    <option value="cancelled">Cancelled</option>
                   </select>
                 </div>
               </div>

--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -686,9 +686,7 @@ const Jobs = () => {
                 >
                   <option value="all">All Status</option>
                   <option value="scheduled">Scheduled</option>
-                  <option value="in_progress">In Progress</option>
                   <option value="completed">Completed</option>
-                  <option value="cancelled">Cancelled</option>
                 </select>
               </div>
             )}

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -79,7 +79,7 @@ const runMigrations = async () => {
         delivery_date DATE NOT NULL,
         special_instructions TEXT,
         paid BOOLEAN DEFAULT FALSE,
-        status VARCHAR(20) DEFAULT 'scheduled' CHECK (status IN ('scheduled', 'in_progress', 'completed', 'cancelled')),
+        status VARCHAR(20) DEFAULT 'scheduled' CHECK (status IN ('scheduled', 'completed', 'to_be_scheduled')),
         driver_notes TEXT,
         payment_received DECIMAL(10,2) DEFAULT 0,
         total_amount DECIMAL(10,2) DEFAULT 0,

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -361,7 +361,7 @@ router.post('/', auth, requireOfficeOrAdmin, async (req, res) => {
     }
 
     // Validate status
-    const validStatuses = ['scheduled', 'to_be_scheduled', 'in_progress', 'completed', 'cancelled'];
+    const validStatuses = ['scheduled', 'to_be_scheduled', 'completed'];
     const jobStatus = status && validStatuses.includes(status) ? status : 
                      (delivery_date ? 'scheduled' : 'to_be_scheduled');
 


### PR DESCRIPTION
## Summary
- Let office and admin users mark deliveries as completed
- Remove cancelled and in-progress statuses from UI and backend
- Clean up docs and styles for obsolete statuses

## Testing
- `cd server && npm test`
- `cd ../client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb86c6e2408330bc611749ca3b00ed