### PR TITLE
Fix driver job filtering for schedule view

### DIFF
--- a/client/src/components/JobDetailModal.jsx
+++ b/client/src/components/JobDetailModal.jsx
@@ -368,10 +368,10 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
           </div>
 
           {/* Driver Actions - Complete Delivery */}
-          {user?.role === 'driver' && job.status === 'scheduled' && job.assigned_driver === user.userId && (
+          {user?.role === 'driver' && job.status === 'scheduled' && job.assigned_driver === (user.id ?? user.userId) && (
             <div className="space-y-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
               <h3 className="font-medium text-blue-900">Complete Delivery</h3>
-              
+
               <div className="space-y-3">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -295,8 +295,10 @@ const Jobs = () => {
 
   // DRIVER VIEW: Enhanced, focused interface
   if (user?.role === 'driver') {
+    // user.id is returned from the auth endpoint; fall back to user.userId for compatibility
+    const currentUserId = user.id ?? user.userId;
     const myJobs = jobs.filter(job =>
-      job.assigned_driver === user.userId &&
+      job.assigned_driver === currentUserId &&
       job.status !== 'to_be_scheduled' &&
       job.delivery_date
     );


### PR DESCRIPTION
## Summary
- Correct driver job filtering by using the authenticated user's `id`
- Align driver action checks with new user id handling

## Testing
- `npm test` *(fails: Missing script "test" as no tests are defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8737341c8330917fd0638e45e722