### PR TITLE
Add reusable status badge for job cards

### DIFF
--- a/client/src/components/JobDetailModal.jsx
+++ b/client/src/components/JobDetailModal.jsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { 
-  X, 
-  MapPin, 
-  Phone, 
-  Package, 
-  DollarSign, 
-  AlertTriangle, 
+import {
+  X,
+  MapPin,
+  Phone,
+  Package,
+  DollarSign,
+  AlertTriangle,
   CheckCircle,
   Edit,
   Save,
@@ -15,6 +15,7 @@ import {
   Trash2
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import StatusBadge from './StatusBadge';
 import toast from 'react-hot-toast';
 
 const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
@@ -336,9 +337,7 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
             <div className="bg-gray-50 rounded-lg p-4">
               <div className="flex items-center justify-between mb-3">
                 <span className="text-sm font-medium text-gray-700">Current Status</span>
-                <span className={`status-${job.status}`}>
-                  {job.status.replace('_', ' ').toUpperCase()}
-                </span>
+                <StatusBadge status={job.status} />
               </div>
 
               {job.delivery_date && (

--- a/client/src/components/StatusBadge.jsx
+++ b/client/src/components/StatusBadge.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Clock, CheckCircle } from 'lucide-react';
+
+const statusStyles = {
+  scheduled: 'bg-indigo-100 text-indigo-800 border border-indigo-300',
+  in_progress: 'bg-blue-100 text-blue-800 border border-blue-300',
+  completed: 'bg-green-200 text-green-800 border border-green-500',
+  cancelled: 'bg-red-100 text-red-800 border border-red-300',
+};
+
+export default function StatusBadge({ status }) {
+  const baseClasses = 'inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold';
+  const className = `${baseClasses} ${statusStyles[status] || ''}`;
+
+  return (
+    <span className={className}>
+      {status === 'scheduled' && <Clock className="h-3 w-3" />}
+      {status === 'completed' && <CheckCircle className="h-3 w-3" />}
+      {status.replace('_', ' ').toUpperCase()}
+    </span>
+  );
+}

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { Calendar, Package, Users, TrendingUp, Clock, CheckCircle } from 'lucide-react';
 import LoadingSpinner from '../components/LoadingSpinner';
+import StatusBadge from '../components/StatusBadge';
 
 // Ensure dates are handled in Eastern Time to avoid timezone-related issues
 const LOCAL_TIME_ZONE = 'America/New_York';
@@ -181,9 +182,7 @@ const Dashboard = () => {
                     </p>
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className={`status-${job.status}`}>
-                      {job.status.replace('_', ' ')}
-                    </span>
+                    <StatusBadge status={job.status} />
                     {job.status === 'scheduled' && (
                       <Clock className="h-4 w-4 text-yellow-600" />
                     )}

--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { 
+import {
   Calendar,
   Plus,
   Search,
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react';
 import LoadingSpinner from '../components/LoadingSpinner';
 import JobDetailModal from '../components/JobDetailModal';
+import StatusBadge from '../components/StatusBadge';
 import toast from 'react-hot-toast';
 
 const LOCAL_TIME_ZONE = 'America/New_York';
@@ -867,11 +868,7 @@ const DriverJobCard = ({ job, onClick, drivers, getDriverName, formatDate, showD
 
         {/* Status and arrow */}
         <div className="flex items-center gap-2 flex-shrink-0 ml-4">
-          <span className={`status-${job.status}`}>
-            {job.status === 'scheduled' && <Clock className="h-3 w-3" />}
-            {job.status === 'completed' && <CheckCircle className="h-3 w-3" />}
-            {job.status.replace('_', ' ').toUpperCase()}
-          </span>
+          <StatusBadge status={job.status} />
           <ChevronRight className="h-5 w-5 text-gray-400" />
         </div>
       </div>
@@ -942,11 +939,7 @@ const MobileJobCard = ({ job, onClick, onUpdateSchedule, isOffice, showSchedulin
                     To Schedule
                   </span>
                 ) : (
-                  <span className={`status-${job.status}`}>
-                    {job.status === 'scheduled' && <Clock className="h-3 w-3" />}
-                    {job.status === 'completed' && <CheckCircle className="h-3 w-3" />}
-                    {job.status.replace('_', ' ').toUpperCase()}
-                  </span>
+                  <StatusBadge status={job.status} />
                 )}
 
                 {/* Payment indicator - prominent for unpaid */}


### PR DESCRIPTION
## Summary
- create StatusBadge component to render job status labels with colored badges
- use StatusBadge on job lists, dashboard, and job detail modal

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb87a65194833094456b718711d65b