### PR TITLE
feat: improve mobile display for products

### DIFF
--- a/client/src/pages/Products.jsx
+++ b/client/src/pages/Products.jsx
@@ -292,105 +292,175 @@ const Products = () => {
            <p>Add your first product to get started</p>
          </div>
        ) : (
-         <div className="overflow-x-auto">
-           <table className="w-full">
-             <thead className="bg-gray-50">
-               <tr>
-                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                   Product
-                 </th>
-                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                   Unit
-                 </th>
-                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                   <div className="flex items-center gap-1">
-                     <User className="h-4 w-4" />
-                     Retail Price
+         <>
+           <div className="md:hidden divide-y">
+             {products.map((product) => (
+               <div key={product.id} className="p-4">
+                 <div className="flex justify-between">
+                   <div className="flex items-center">
+                     <Package className="h-5 w-5 text-gray-400 mr-3" />
+                     <span className="text-sm font-medium text-gray-900">
+                       {product.name}
+                     </span>
                    </div>
-                 </th>
-                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                   <div className="flex items-center gap-1">
-                     <Users className="h-4 w-4" />
-                     Contractor Price
+                   <div className="flex items-center gap-2">
+                     <button
+                       onClick={() => handleEdit(product)}
+                       className="text-nursery-600 hover:text-nursery-700"
+                     >
+                       <Edit className="h-4 w-4" />
+                     </button>
+                     <button
+                       onClick={() => handleDelete(product.id)}
+                       className="text-red-600 hover:text-red-700"
+                     >
+                       <Trash2 className="h-4 w-4" />
+                     </button>
                    </div>
-                 </th>
-                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                   Status
-                 </th>
-                 <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                   Actions
-                 </th>
-               </tr>
-             </thead>
-             <tbody className="bg-white divide-y divide-gray-200">
-               {products.map((product) => (
-                 <tr key={product.id} className="hover:bg-gray-50">
-                   <td className="px-6 py-4 whitespace-nowrap">
-                     <div className="flex items-center">
-                       <Package className="h-5 w-5 text-gray-400 mr-3" />
-                       <span className="text-sm font-medium text-gray-900">
-                         {product.name}
-                       </span>
-                     </div>
-                   </td>
-                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                     {product.unit}
-                   </td>
-                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                 </div>
+                 <div className="mt-2 text-sm text-gray-600 space-y-1">
+                   <div>
+                     <span className="font-medium">Unit:</span> {product.unit}
+                   </div>
+                   <div className="flex items-center gap-1">
+                     <User className="h-4 w-4 text-gray-400" />
                      {product.retail_price ? (
-                       <div className="flex items-center">
-                         <DollarSign className="h-4 w-4 text-gray-400" />
-                         {parseFloat(product.retail_price).toFixed(2)}
-                       </div>
+                       <span>{parseFloat(product.retail_price).toFixed(2)}</span>
                      ) : (
                        <span className="text-gray-400">No price</span>
                      )}
-                   </td>
-                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                   </div>
+                   <div className="flex items-center gap-1">
+                     <Users className="h-4 w-4 text-gray-400" />
                      {product.contractor_price ? (
-                       <div className="flex items-center">
-                         <DollarSign className="h-4 w-4 text-gray-400" />
-                         {parseFloat(product.contractor_price).toFixed(2)}
+                       <>
+                         <span>{parseFloat(product.contractor_price).toFixed(2)}</span>
                          {product.retail_price && (
-                           <span className="ml-2 text-xs text-green-600">
+                           <span className="ml-1 text-xs text-green-600">
                              ({(((parseFloat(product.retail_price) - parseFloat(product.contractor_price)) / parseFloat(product.retail_price)) * 100).toFixed(0)}% off)
                            </span>
                          )}
-                       </div>
+                       </>
                      ) : (
                        <span className="text-gray-400">No price</span>
                      )}
-                   </td>
-                   <td className="px-6 py-4 whitespace-nowrap">
-                     <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                       product.active 
-                         ? 'bg-green-100 text-green-800'
-                         : 'bg-gray-100 text-gray-800'
-                     }`}>
+                   </div>
+                   <div>
+                     <span
+                       className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                         product.active
+                           ? 'bg-green-100 text-green-800'
+                           : 'bg-gray-100 text-gray-800'
+                       }`}
+                     >
                        {product.active ? 'Active' : 'Inactive'}
                      </span>
-                   </td>
-                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                     <div className="flex items-center justify-end gap-2">
-                       <button
-                         onClick={() => handleEdit(product)}
-                         className="text-nursery-600 hover:text-nursery-700"
-                       >
-                         <Edit className="h-4 w-4" />
-                       </button>
-                       <button
-                         onClick={() => handleDelete(product.id)}
-                         className="text-red-600 hover:text-red-700"
-                       >
-                         <Trash2 className="h-4 w-4" />
-                       </button>
+                   </div>
+                 </div>
+               </div>
+             ))}
+           </div>
+
+           <div className="hidden md:block overflow-x-auto">
+             <table className="w-full">
+               <thead className="bg-gray-50">
+                 <tr>
+                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                     Product
+                   </th>
+                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                     Unit
+                   </th>
+                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                     <div className="flex items-center gap-1">
+                       <User className="h-4 w-4" />
+                       Retail Price
                      </div>
-                   </td>
+                   </th>
+                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                     <div className="flex items-center gap-1">
+                       <Users className="h-4 w-4" />
+                       Contractor Price
+                     </div>
+                   </th>
+                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                     Status
+                   </th>
+                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                     Actions
+                   </th>
                  </tr>
-               ))}
-             </tbody>
-           </table>
-         </div>
+               </thead>
+               <tbody className="bg-white divide-y divide-gray-200">
+                 {products.map((product) => (
+                   <tr key={product.id} className="hover:bg-gray-50">
+                     <td className="px-6 py-4 whitespace-nowrap">
+                       <div className="flex items-center">
+                         <Package className="h-5 w-5 text-gray-400 mr-3" />
+                         <span className="text-sm font-medium text-gray-900">
+                           {product.name}
+                         </span>
+                       </div>
+                     </td>
+                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                       {product.unit}
+                     </td>
+                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                       {product.retail_price ? (
+                         <div className="flex items-center">
+                           <DollarSign className="h-4 w-4 text-gray-400" />
+                           {parseFloat(product.retail_price).toFixed(2)}
+                         </div>
+                       ) : (
+                         <span className="text-gray-400">No price</span>
+                       )}
+                     </td>
+                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                       {product.contractor_price ? (
+                         <div className="flex items-center">
+                           <DollarSign className="h-4 w-4 text-gray-400" />
+                           {parseFloat(product.contractor_price).toFixed(2)}
+                           {product.retail_price && (
+                             <span className="ml-2 text-xs text-green-600">
+                               ({(((parseFloat(product.retail_price) - parseFloat(product.contractor_price)) / parseFloat(product.retail_price)) * 100).toFixed(0)}% off)
+                             </span>
+                           )}
+                         </div>
+                       ) : (
+                         <span className="text-gray-400">No price</span>
+                       )}
+                     </td>
+                     <td className="px-6 py-4 whitespace-nowrap">
+                       <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                         product.active
+                           ? 'bg-green-100 text-green-800'
+                           : 'bg-gray-100 text-gray-800'
+                       }`}>
+                         {product.active ? 'Active' : 'Inactive'}
+                       </span>
+                     </td>
+                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                       <div className="flex items-center justify-end gap-2">
+                         <button
+                           onClick={() => handleEdit(product)}
+                           className="text-nursery-600 hover:text-nursery-700"
+                         >
+                           <Edit className="h-4 w-4" />
+                         </button>
+                         <button
+                           onClick={() => handleDelete(product.id)}
+                           className="text-red-600 hover:text-red-700"
+                         >
+                           <Trash2 className="h-4 w-4" />
+                         </button>
+                       </div>
+                     </td>
+                   </tr>
+                 ))}
+               </tbody>
+             </table>
+           </div>
+         </>
        )}
      </div>
    </div>


### PR DESCRIPTION
## Summary
- show products as mobile-friendly cards
- keep existing table for desktop views only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb935f09ec8330843479fe832069e5