### PR TITLE
Add favicon links to main HTML head

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,16 +2,20 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/client/public/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/client/public/favicon.svg" />
+    <link rel="shortcut icon" href="/client/public/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/client/public/apple-touch-icon.png" />
+    <meta name="apple-mobile-web-app-title" content="Delivery" />
+    <link rel="manifest" href="/client/public/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="East Meadow Nursery delivery scheduling application for efficient landscape product delivery management" />
     <meta name="theme-color" content="#16a34a" />
-    
+
     <!-- PWA Meta Tags -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="East Meadow Delivery" />
-    
+
     <!-- Preconnect to improve performance -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add multiple favicon, touch icon, and manifest links to HTML head

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68be3b81e52c833080478fe4e5196c98