### PR TITLE
Improve mobile progress step header

### DIFF
--- a/client/src/components/ProgressSteps.jsx
+++ b/client/src/components/ProgressSteps.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+/**
+ * Responsive progress indicator for multi-step forms.
+ * Renders step numbers as circles and allows horizontal scrolling on mobile
+ * so the header never gets squished.
+ */
+const ProgressSteps = ({ steps = [], currentStep = 1 }) => {
+  return (
+    <div className="overflow-x-auto">
+      <ol className="flex items-center space-x-4 min-w-max p-4">
+        {steps.map((label, index) => {
+          const stepNumber = index + 1;
+          const isActive = stepNumber === currentStep;
+          const isCompleted = stepNumber < currentStep;
+
+          const circleClass = [
+            'flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center border',
+            isActive
+              ? 'bg-green-600 text-white border-green-600'
+              : isCompleted
+              ? 'bg-green-100 text-green-800 border-green-600'
+              : 'bg-white text-gray-500 border-gray-300'
+          ].join(' ');
+
+          return (
+            <li key={label} className="flex items-center space-x-2">
+              <span className={circleClass}>{stepNumber}</span>
+              <span className="text-sm whitespace-nowrap">{label}</span>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+};
+
+export default ProgressSteps;

--- a/client/src/pages/AddJob.jsx
+++ b/client/src/pages/AddJob.jsx
@@ -5,6 +5,7 @@ import { Plus, X, ArrowLeft, DollarSign, Calculator, Clock } from 'lucide-react'
 import toast from 'react-hot-toast';
 import LoadingSpinner from '../components/LoadingSpinner';
 import CustomerSearch from '../components/CustomerSearch';
+import ProgressSteps from '../components/ProgressSteps';
 
 // Consistently use Eastern Time for date handling
 const LOCAL_TIME_ZONE = 'America/New_York';
@@ -372,6 +373,10 @@ const AddJob = () => {
   return (
     <div className="p-6">
       <div className="max-w-2xl mx-auto">
+        <ProgressSteps
+          steps={["Date & Basic Info", "Equipment & Labor", "Materials"]}
+          currentStep={1}
+        />
         <div className="bg-white rounded-lg shadow-sm border">
           {/* Header */}
           <div className="flex items-center justify-between p-6 border-b">


### PR DESCRIPTION
## Summary
- add mobile-friendly `ProgressSteps` component with circular step markers
- show progress steps on AddJob page for better navigation

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4b9128448330ad5a096d635ebe78