### PR TITLE
feat: make dashboard recent jobs clickable

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -174,7 +174,11 @@ const Dashboard = () => {
           ) : (
             <div className="space-y-3">
               {recentJobs.map((job) => (
-                <div key={job.id} className="flex items-center justify-between p-3 border border-gray-200 rounded-lg">
+                <Link
+                  key={job.id}
+                  to={`/jobs?jobId=${job.id}`}
+                  className="flex items-center justify-between p-3 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+                >
                   <div className="flex-1">
                     <p className="font-medium text-gray-900">{job.customer_name}</p>
                     <p className="text-sm text-gray-600">
@@ -190,7 +194,7 @@ const Dashboard = () => {
                       <CheckCircle className="h-4 w-4 text-green-600" />
                     )}
                   </div>
-                </div>
+                </Link>
               ))}
               <div className="pt-2 border-t">
                 <Link

--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import {
   Calendar,
@@ -28,6 +28,7 @@ const getTodayDate = () =>
 
 const Jobs = () => {
   const { isOffice, user, makeAuthenticatedRequest } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [jobs, setJobs] = useState([]);
   const [filteredJobs, setFilteredJobs] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -107,6 +108,17 @@ const Jobs = () => {
     }
     // Include loading so scroll happens after jobs are fetched
   }, [selectedDate, loading]);
+
+  useEffect(() => {
+    const jobIdParam = searchParams.get('jobId');
+    if (jobIdParam && jobs.length > 0) {
+      const jobToOpen = jobs.find(job => job.id === parseInt(jobIdParam));
+      if (jobToOpen) {
+        setSelectedJob(jobToOpen);
+        setShowJobModal(true);
+      }
+    }
+  }, [searchParams, jobs]);
 
   const fetchDrivers = async () => {
     try {
@@ -557,6 +569,9 @@ const Jobs = () => {
         onClose={() => {
           setShowJobModal(false);
           setSelectedJob(null);
+          const params = new URLSearchParams(searchParams);
+          params.delete('jobId');
+          setSearchParams(params);
         }}
         onUpdate={handleJobUpdate}
         drivers={drivers}


### PR DESCRIPTION
## Summary
- Link recent dashboard job cards to open job details
- Automatically open job details modal when jobId query is present and clear URL on close

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf87d64e588330acc322a23b8d69c2