### PR TITLE
Allow admins to complete and reschedule deliveries

### DIFF
--- a/client/src/components/JobDetailModal.jsx
+++ b/client/src/components/JobDetailModal.jsx
@@ -46,7 +46,7 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
   };
 
   useEffect(() => {
-    if (isEditing && isOffice && job) {
+    if (isEditing && (isOffice || isAdmin) && job) {
       setEditProducts(
         job.products && job.products.length > 0
           ? job.products.map(p => ({ ...p }))
@@ -152,7 +152,7 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
   };
 
   const handleSaveEdit = async () => {
-    if (!isOffice) return;
+    if (!(isOffice || isAdmin)) return;
 
     setLoading(true);
     try {
@@ -287,7 +287,7 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
             <div className="bg-gray-50 rounded-lg p-4 space-y-3">
               <div>
                 <div className="text-sm font-medium text-gray-700">Customer Name</div>
-                {isEditing && isOffice ? (
+                {isEditing && (isOffice || isAdmin) ? (
                   <input
                     type="text"
                     value={editData.customer_name ?? job.customer_name}
@@ -302,7 +302,7 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
               {job.customer_phone && (
                 <div className="flex items-center gap-2">
                   <Phone className="h-4 w-4 text-gray-500" />
-                  {isEditing && isOffice ? (
+                  {isEditing && (isOffice || isAdmin) ? (
                     <input
                       type="tel"
                       value={editData.customer_phone ?? job.customer_phone}
@@ -327,7 +327,7 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
             </h3>
             
             <div className="bg-gray-50 rounded-lg p-4">
-              {isEditing && isOffice ? (
+              {isEditing && (isOffice || isAdmin) ? (
                 <textarea
                   value={editData.address ?? job.address}
                   onChange={(e) => handleEditChange('address', e.target.value)}
@@ -361,7 +361,7 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
             </h3>
             
             <div className="bg-gray-50 rounded-lg p-4">
-              {isEditing && isOffice ? (
+              {isEditing && (isOffice || isAdmin) ? (
                 <div className="space-y-4">
                   {editProducts.map((product, index) => {
                     const selectedProduct = availableProducts.find(p => p.name === product.product_name);
@@ -487,7 +487,7 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
               </h3>
               
               <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-                {isEditing && isOffice ? (
+                {isEditing && (isOffice || isAdmin) ? (
                   <textarea
                     value={editData.special_instructions ?? job.special_instructions}
                     onChange={(e) => handleEditChange('special_instructions', e.target.value)}
@@ -545,7 +545,7 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
             (user?.role === 'driver' &&
               job.status === 'scheduled' &&
               job.assigned_driver === (user.id ?? user.userId)) ||
-            (isOffice && job.status !== 'completed')
+            ((isOffice || isAdmin) && job.status !== 'completed')
           ) && (
             <div className="space-y-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
               <h3 className="font-medium text-blue-900">Complete Delivery</h3>
@@ -613,8 +613,8 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
           )}
         </div>
 
-        {/* Footer Actions - Office Only */}
-        {isOffice && (
+        {/* Footer Actions - Office/Admin Only */}
+        {(isOffice || isAdmin) && (
           <div className="sticky bottom-0 bg-white border-t p-4 flex gap-3">
             {isEditing ? (
               <>

--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -27,7 +27,7 @@ const getTodayDate = () =>
   new Intl.DateTimeFormat('en-CA', { timeZone: LOCAL_TIME_ZONE }).format(new Date());
 
 const Jobs = () => {
-  const { isOffice, user, makeAuthenticatedRequest } = useAuth();
+  const { isOffice, isAdmin, user, makeAuthenticatedRequest } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const [jobs, setJobs] = useState([]);
   const [filteredJobs, setFilteredJobs] = useState([]);
@@ -92,10 +92,10 @@ const Jobs = () => {
 
   useEffect(() => {
     fetchJobs();
-    if (isOffice) {
+    if (isOffice || isAdmin) {
       fetchDrivers();
     }
-  }, [isOffice, user]);
+  }, [isOffice, isAdmin, user]);
 
   useEffect(() => {
     filterJobs();
@@ -320,7 +320,7 @@ const Jobs = () => {
           East Meadow Delivery Schedule
         </h1>
         <div className="flex gap-2">
-          {isOffice && (
+          {(isOffice || isAdmin) && (
             <Link
               to="/jobs/add"
               className="btn-primary flex items-center gap-2"
@@ -346,8 +346,8 @@ const Jobs = () => {
           </div>
         )}
 
-        {/* Unscheduled Jobs Alert - Office Only */}
-        {unscheduledJobs > 0 && isOffice && (
+        {/* Unscheduled Jobs Alert - Office/Admin */}
+        {unscheduledJobs > 0 && (isOffice || isAdmin) && (
           <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
@@ -534,7 +534,7 @@ const Jobs = () => {
                 : `No jobs found for ${selectedDate}. Try selecting a different date.`
               }
             </p>
-            {isOffice && (
+            {(isOffice || isAdmin) && (
               <Link
                 to="/jobs/add"
                 className="inline-block mt-4 btn-primary"
@@ -551,7 +551,7 @@ const Jobs = () => {
                 job={job}
                 onClick={() => handleJobClick(job)}
                 onUpdateSchedule={updateJobSchedule}
-                isOffice={isOffice}
+                isOffice={isOffice || isAdmin}
                 showScheduling={showToBeScheduled}
                 drivers={drivers}
                 getDriverName={getDriverName}


### PR DESCRIPTION
## Summary
- Allow admins to edit delivery details and mark jobs as completed
- Let admins access scheduling controls alongside office staff

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix client run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68bf949f43948330a67036040df71d5e