### PR TITLE
fix: prevent selected day card clipping

### DIFF
--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -382,7 +382,7 @@ const Jobs = () => {
             <p className="text-sm text-gray-600 mt-1">Choose a date to view scheduled deliveries</p>
           </div>
           <div className="p-4">
-            <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide" ref={weekScrollRef}>
+            <div className="flex gap-3 overflow-x-auto overflow-y-visible pb-2 scrollbar-hide" ref={weekScrollRef}>
               {generateCalendarDays().map((day) => (
                 <button
                   key={day.date}


### PR DESCRIPTION
## Summary
- ensure selected calendar day isn't clipped by allowing vertical overflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd client && npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9bd39bb88330b673d86dbdbb9719