### PR TITLE
Update delivery scheduling for manual collections and truck assignments

### DIFF
--- a/client/src/pages/AddJob.jsx
+++ b/client/src/pages/AddJob.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { Plus, X, ArrowLeft, DollarSign, Calculator, Clock } from 'lucide-react';
+import { Plus, X, ArrowLeft, DollarSign, Clock, Truck } from 'lucide-react';
 import toast from 'react-hot-toast';
 import LoadingSpinner from '../components/LoadingSpinner';
 import CustomerSearch from '../components/CustomerSearch';
@@ -28,7 +28,9 @@ const AddJob = () => {
     special_instructions: '',
     paid: false,
     assigned_driver: '',
-    products: [{ product_name: '', quantity: '', unit: 'yards', unit_price: 0, total_price: 0 }]
+    products: [{ product_name: '', quantity: '', unit: 'yards' }],
+    collection_amount: '',
+    truck: ''
   });
 
   const unitOptions = ['yards', 'tons', 'bags', 'each'];
@@ -41,12 +43,6 @@ const AddJob = () => {
     fetchDrivers();
     fetchProducts();
   }, [isOffice, navigate]);
-
-  useEffect(() => {
-    if (selectedCustomer) {
-      fetchProductsWithPricing();
-    }
-  }, [selectedCustomer]);
 
   const fetchDrivers = async () => {
     try {
@@ -61,36 +57,11 @@ const AddJob = () => {
     try {
       const response = await makeAuthenticatedRequest('get', '/products/active');
       const products = response.data.products || [];
-      
-      const productsWithPricing = products.map(product => ({
-        ...product,
-        current_price: product.retail_price || product.price_per_unit || 0
-      }));
-      
-      setProducts(productsWithPricing);
-      console.log('✅ Products loaded:', productsWithPricing.length);
+
+      setProducts(products);
+      console.log('✅ Products loaded:', products.length);
     } catch (error) {
       console.error('Failed to fetch products:', error);
-    }
-  };
-
-  const fetchProductsWithPricing = async () => {
-    if (!selectedCustomer) return;
-    
-    try {
-      const response = await makeAuthenticatedRequest('get', `/products/pricing/${selectedCustomer.id}`);
-      const products = response.data.products || [];
-      
-      const productsWithPricing = products.map(product => ({
-        ...product,
-        current_price: product.current_price || product.retail_price || product.contractor_price || 0
-      }));
-      
-      setProducts(productsWithPricing);
-      console.log('✅ Products with customer pricing loaded:', productsWithPricing.length);
-    } catch (error) {
-      console.error('Failed to fetch product pricing:', error);
-      fetchProducts();
     }
   };
 
@@ -186,26 +157,6 @@ const AddJob = () => {
     const updatedProducts = [...formData.products];
     updatedProducts[index][field] = value;
 
-    if (field === 'product_name' || field === 'quantity') {
-      const selectedProduct = products.find(p => p.name === updatedProducts[index].product_name);
-      if (selectedProduct && updatedProducts[index].quantity) {
-        const unitPrice = selectedProduct.current_price || 0;
-        const quantity = parseFloat(updatedProducts[index].quantity) || 0;
-        updatedProducts[index].unit_price = unitPrice;
-        updatedProducts[index].total_price = unitPrice * quantity;
-        
-        console.log('Updated product pricing:', {
-          product: selectedProduct.name,
-          unitPrice,
-          quantity,
-          total: unitPrice * quantity
-        });
-      } else {
-        updatedProducts[index].unit_price = 0;
-        updatedProducts[index].total_price = 0;
-      }
-    }
-
     setFormData(prev => ({
       ...prev,
       products: updatedProducts
@@ -215,7 +166,7 @@ const AddJob = () => {
   const addProduct = () => {
     setFormData(prev => ({
       ...prev,
-      products: [...prev.products, { product_name: '', quantity: '', unit: 'yards', unit_price: 0, total_price: 0 }]
+      products: [...prev.products, { product_name: '', quantity: '', unit: 'yards' }]
     }));
   };
 
@@ -227,10 +178,6 @@ const AddJob = () => {
         products: updatedProducts
       }));
     }
-  };
-
-  const calculateTotal = () => {
-    return formData.products.reduce((total, product) => total + (product.total_price || 0), 0);
   };
 
   const createCustomerIfNeeded = async () => {
@@ -328,16 +275,17 @@ const AddJob = () => {
         products: formData.products.map(p => ({
           product_name: p.product_name,
           quantity: parseFloat(p.quantity),
-          unit: p.unit,
-          unit_price: p.unit_price,
-          total_price: p.total_price,
-          price_type: selectedCustomer?.contractor ? 'contractor' : 'retail'
+          unit: p.unit
         })),
-        total_amount: calculateTotal(),
+        total_amount: formData.collection_amount ? parseFloat(formData.collection_amount) : 0,
         contractor_discount: selectedCustomer?.contractor || false,
         // Add status to indicate if it needs scheduling
         status: toBeScheduled ? 'to_be_scheduled' : 'scheduled'
       };
+
+      if (formData.truck && formData.truck.trim()) {
+        submitData.truck = formData.truck.trim();
+      }
 
       if (customerId) {
         submitData.customer_id = customerId;
@@ -366,8 +314,6 @@ const AddJob = () => {
   if (!isOffice) {
     return null;
   }
-
-  const orderTotal = calculateTotal();
 
   return (
     <div className="p-6">
@@ -498,10 +444,32 @@ const AddJob = () => {
                 </div>
               )}
 
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Truck
+                </label>
+                <div className="relative">
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <Truck className="h-4 w-4 text-gray-400" />
+                  </div>
+                  <input
+                    type="text"
+                    name="truck"
+                    value={formData.truck}
+                    onChange={handleInputChange}
+                    className="input-field pl-9"
+                    placeholder="e.g. Dump Truck 2"
+                  />
+                </div>
+                <p className="mt-2 text-xs text-gray-500">
+                  Let drivers know which vehicle to use for this delivery.
+                </p>
+              </div>
+
               {toBeScheduled && (
                 <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
                   <p className="text-yellow-800 text-sm">
-                    <strong>📅 Scheduling Note:</strong> This order will be saved without a delivery date. 
+                    <strong>📅 Scheduling Note:</strong> This order will be saved without a delivery date.
                     You can set the date and assign a driver later from the Jobs page.
                   </p>
                 </div>
@@ -571,8 +539,8 @@ const AddJob = () => {
                           <option value="">Select product</option>
                           {products.map(p => (
                             <option key={p.id} value={p.name}>
-                              {p.name} - ${parseFloat(p.current_price || 0).toFixed(2)}/{p.unit}
-                              {selectedCustomer?.contractor && p.price_type === 'contractor' && ' (Contractor Price)'}
+                              {p.name}
+                              {p.unit ? ` (${p.unit})` : ''}
                             </option>
                           ))}
                         </select>
@@ -610,48 +578,43 @@ const AddJob = () => {
                       </div>
                     </div>
 
-                    {/* Price Display */}
-                    {selectedProduct && product.quantity && (
-                      <div className="mt-3 p-3 bg-gray-50 rounded-lg">
-                        <div className="flex justify-between items-center text-sm">
-                          <span className="text-gray-600">
-                            {product.quantity} {product.unit} × ${parseFloat(selectedProduct.current_price || 0).toFixed(2)}
-                            {selectedCustomer?.contractor && (
-                              <span className="text-blue-600 ml-1">(Contractor Price)</span>
-                            )}
-                          </span>
-                          <span className="font-medium text-gray-900">
-                            ${product.total_price.toFixed(2)}
-                          </span>
-                        </div>
+                    {/* Unit Display */}
+                    {selectedProduct && selectedProduct.unit && (
+                      <div className="mt-3 p-3 bg-gray-50 rounded-lg text-sm text-gray-600">
+                        <span className="font-medium text-gray-900">Unit:</span> {selectedProduct.unit}
                       </div>
                     )}
                   </div>
                 );
               })}
-
-              {/* Order Total */}
-              {orderTotal > 0 && (
-                <div className="bg-eastmeadow-50 border border-eastmeadow-200 rounded-lg p-4">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <Calculator className="h-5 w-5 text-eastmeadow-600" />
-                      <span className="font-medium text-eastmeadow-900">Order Total</span>
-                      {selectedCustomer?.contractor && (
-                        <span className="text-sm text-blue-600">(With Contractor Pricing)</span>
-                      )}
-                    </div>
-                    <span className="text-xl font-bold text-eastmeadow-900">
-                      ${orderTotal.toFixed(2)}
-                    </span>
-                  </div>
-                </div>
-              )}
             </div>
 
             {/* Payment Status */}
             <div className="space-y-4">
               <h2 className="text-lg font-medium text-gray-900">Payment</h2>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Amount to Collect (Optional)
+                </label>
+                <div className="relative">
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <DollarSign className="h-4 w-4 text-gray-400" />
+                  </div>
+                  <input
+                    type="number"
+                    name="collection_amount"
+                    value={formData.collection_amount}
+                    onChange={handleInputChange}
+                    className="input-field pl-9"
+                    step="0.01"
+                    min="0"
+                    placeholder="0.00"
+                  />
+                </div>
+                <p className="mt-2 text-xs text-gray-500">
+                  Enter the amount the driver should collect at delivery, if any.
+                </p>
+              </div>
               <div className="flex items-center">
                 <input
                   type="checkbox"
@@ -663,11 +626,6 @@ const AddJob = () => {
                 />
                 <label htmlFor="paid" className="ml-2 text-sm text-gray-700">
                   Payment has been received
-                  {orderTotal > 0 && (
-                    <span className="ml-1 text-gray-500">
-                      (${orderTotal.toFixed(2)})
-                    </span>
-                  )}
                 </label>
               </div>
             </div>

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -14,7 +14,7 @@ const Dashboard = () => {
     todayJobs: 0,
     totalJobs: 0,
     completedJobs: 0,
-    pendingPayments: 0
+    pendingCollections: 0
   });
   const [recentJobs, setRecentJobs] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -41,11 +41,12 @@ const Dashboard = () => {
         todayJobs: todayJobs.length,
         totalJobs: allJobs.length,
         completedJobs: allJobs.filter(job => job.status === 'completed').length,
-        pendingPayments: allJobs.filter(job => {
-          const total = job.total_amount || 0;
-          const received = job.payment_received || 0;
-          const isPaid = job.paid || (total > 0 && received >= total);
-          return job.status === 'completed' && !isPaid;
+        pendingCollections: allJobs.filter(job => {
+          const total = parseFloat(job.total_amount) || 0;
+          const received = parseFloat(job.payment_received) || 0;
+          const requiresCollection = total > 0;
+          const isSettled = job.paid || !requiresCollection || received >= total;
+          return job.status === 'completed' && requiresCollection && !isSettled;
         }).length
       });
 
@@ -58,7 +59,7 @@ const Dashboard = () => {
         todayJobs: 0,
         totalJobs: 0,
         completedJobs: 0,
-        pendingPayments: 0
+        pendingCollections: 0
       });
     } finally {
       setLoading(false);
@@ -106,8 +107,8 @@ const Dashboard = () => {
             color="emerald"
           />
           <StatItem
-            title="Pending Payments"
-            value={stats.pendingPayments}
+            title="Pending Collections"
+            value={stats.pendingCollections}
             icon={TrendingUp}
             color="orange"
           />

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -86,11 +86,28 @@ const runMigrations = async () => {
         contractor_discount BOOLEAN DEFAULT FALSE,
         created_by INTEGER REFERENCES users(id),
         assigned_driver INTEGER REFERENCES users(id),
+        truck VARCHAR(100),
         created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
       )
     `);
     console.log('✅ Jobs table ready');
+
+    const jobColumnsResult = await client.query(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_name = 'jobs' AND table_schema = 'public'
+    `);
+    const jobColumnNames = jobColumnsResult.rows.map(row => row.column_name);
+
+    if (!jobColumnNames.includes('truck')) {
+      try {
+        await client.query('ALTER TABLE jobs ADD COLUMN truck VARCHAR(100)');
+        console.log('✅ Added truck column to jobs table');
+      } catch (e) {
+        console.log('⚠️ truck column issue (may already exist):', e.message);
+      }
+    }
 
     // Products table - SAFE MIGRATION
     console.log('🔄 Checking products table...');

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { body, validationResult, param, query } = require('express-validator');
+  const { body, validationResult, param, query } = require('express-validator');
 const db = require('../config/database');
 const auth = require('../middleware/auth');
 
@@ -234,6 +234,7 @@ router.get('/', auth, async (req, res) => {
       assigned_driver: job.assigned_driver ? parseInt(job.assigned_driver) : null,
       total_amount: job.total_amount ? parseFloat(job.total_amount) : 0,
       payment_received: job.payment_received ? parseFloat(job.payment_received) : 0,
+      truck: job.truck || null,
       delivery_date: job.delivery_date
         ? new Date(job.delivery_date).toISOString().split('T')[0]
         : null,
@@ -266,7 +267,7 @@ router.get('/:id', auth, async (req, res) => {
       return res.status(400).json({ message: 'Valid job ID required' });
     }
 
-    const result = await db.query('SELECT * FROM jobs WHERE id = $1', [req.params.id]);
+      const result = await db.query('SELECT * FROM jobs WHERE id = $1', [req.params.id]);
 
     if (result.rows.length === 0) {
       return res.status(404).json({ message: 'Job not found' });
@@ -296,6 +297,7 @@ router.get('/:id', auth, async (req, res) => {
       assigned_driver: job.assigned_driver ? parseInt(job.assigned_driver) : null,
       total_amount: job.total_amount ? parseFloat(job.total_amount) : 0,
       payment_received: job.payment_received ? parseFloat(job.payment_received) : 0,
+      truck: job.truck || null,
       delivery_date: job.delivery_date
         ? new Date(job.delivery_date).toISOString().split('T')[0]
         : null,
@@ -348,7 +350,8 @@ router.post('/', auth, requireOfficeOrAdmin, async (req, res) => {
       total_amount,
       contractor_discount,
       customer_id,
-      status
+      status,
+      truck
     } = req.body;
 
     // Basic validation
@@ -399,9 +402,12 @@ router.post('/', auth, requireOfficeOrAdmin, async (req, res) => {
     const cleanCustomerPhone = (customer_phone && customer_phone.trim()) ? customer_phone.trim() : null;
     const cleanSpecialInstructions = (special_instructions && special_instructions.trim()) ? special_instructions.trim() : null;
     const cleanAssignedDriver = (assigned_driver && !isNaN(assigned_driver)) ? parseInt(assigned_driver) : null;
-    const cleanTotalAmount = (total_amount && !isNaN(total_amount)) ? parseFloat(total_amount) : 0;
+    const cleanTotalAmount = (total_amount !== undefined && total_amount !== null && total_amount !== '' && !isNaN(total_amount))
+      ? parseFloat(total_amount)
+      : 0;
     const isContractorDiscount = contractor_discount === true;
     const isPaid = paid === true;
+    const cleanTruck = (typeof truck === 'string' && truck.trim().length > 0) ? truck.trim() : null;
 
     // For "to_be_scheduled" jobs, delivery_date should be null
     const finalDeliveryDate = jobStatus === 'to_be_scheduled' ? null : delivery_date;
@@ -416,6 +422,7 @@ router.post('/', auth, requireOfficeOrAdmin, async (req, res) => {
       cleanAssignedDriver,
       finalCustomerId,
       cleanTotalAmount,
+      cleanTruck,
       isContractorDiscount,
       status: jobStatus
     });
@@ -470,6 +477,12 @@ router.post('/', auth, requireOfficeOrAdmin, async (req, res) => {
       paramCount++;
     }
 
+    if (availableColumns.includes('truck') && cleanTruck) {
+      insertFields.push('truck');
+      insertValues.push(cleanTruck);
+      paramCount++;
+    }
+
     // Create parameterized query
     const placeholders = insertValues
       .map((_, index) => `$${index + 1}`)
@@ -510,6 +523,7 @@ router.post('/', auth, requireOfficeOrAdmin, async (req, res) => {
       delivery_date: job.delivery_date
         ? new Date(job.delivery_date).toISOString().split('T')[0]
         : null,
+      truck: job.truck || null,
       products: productsResult.rows.map(p => ({
         product_id: p.product_id,
         product_name: p.product_name,
@@ -607,7 +621,7 @@ router.put('/:id', auth, async (req, res) => {
     const potentialUpdates = [
       'customer_name', 'customer_phone', 'address', 'delivery_date',
       'special_instructions', 'status', 'driver_notes',
-      'payment_received', 'assigned_driver', 'total_amount', 'contractor_discount'
+      'payment_received', 'assigned_driver', 'total_amount', 'contractor_discount', 'truck'
     ];
 
     for (const field of potentialUpdates) {
@@ -631,10 +645,25 @@ router.put('/:id', auth, async (req, res) => {
           values.push(value || null);
         } else if (field === 'total_amount') {
           const value = req.body[field];
-          values.push((value !== undefined && value !== null && !isNaN(value)) ? parseFloat(value) : 0);
+          if (value === null || value === undefined || value === '') {
+            values.push(0);
+          } else {
+            const parsed = parseFloat(value);
+            values.push(isNaN(parsed) ? 0 : parsed);
+          }
         } else if (field === 'contractor_discount') {
           const value = req.body[field];
           values.push(value === true);
+        } else if (field === 'truck') {
+          const value = req.body[field];
+          if (value === null || value === undefined) {
+            values.push(null);
+          } else if (typeof value === 'string') {
+            const trimmed = value.trim();
+            values.push(trimmed.length > 0 ? trimmed : null);
+          } else {
+            values.push(null);
+          }
         } else {
           values.push(req.body[field]);
         }
@@ -647,12 +676,19 @@ router.put('/:id', auth, async (req, res) => {
       paidStatus = req.body.paid === true;
     } else {
       const paymentReceived = req.body.payment_received !== undefined
-        ? parseFloat(req.body.payment_received)
+        ? (req.body.payment_received === null || req.body.payment_received === ''
+            ? 0
+            : parseFloat(req.body.payment_received))
         : job.payment_received || 0;
-      const totalAmount = req.body.total_amount !== undefined
-        ? parseFloat(req.body.total_amount)
+      const totalAmountRaw = req.body.total_amount !== undefined
+        ? (req.body.total_amount === null || req.body.total_amount === ''
+            ? 0
+            : parseFloat(req.body.total_amount))
         : job.total_amount || 0;
-      paidStatus = totalAmount > 0 && paymentReceived >= totalAmount;
+      const normalizedTotal = isNaN(totalAmountRaw) ? 0 : totalAmountRaw;
+      const normalizedReceived = isNaN(paymentReceived) ? 0 : paymentReceived;
+      const requiresCollection = normalizedTotal > 0;
+      paidStatus = requiresCollection ? normalizedReceived >= normalizedTotal : true;
     }
 
     if (availableColumns.includes('paid')) {
@@ -712,6 +748,7 @@ router.put('/:id', auth, async (req, res) => {
       delivery_date: result.rows[0].delivery_date
         ? new Date(result.rows[0].delivery_date).toISOString().split('T')[0]
         : null,
+      truck: result.rows[0].truck || null,
       products: productsResult.rows.map(p => ({
         product_id: p.product_id,
         product_name: p.product_name,


### PR DESCRIPTION
## Summary
- replace product price handling on delivery forms with manual "amount to collect" entry and truck assignment fields
- update job detail views, dashboard metrics, and schedule listings to show collection status and truck information
- extend backend schema and job routes to persist truck selections and treat zero collections as settled

## Testing
- npm run client:build

------
https://chatgpt.com/codex/tasks/task_e_68d5630cab408330aa92cdafc80862e4