### PR TITLE
Simplify delivery collection messaging and require driver assignment

### DIFF
--- a/client/src/components/JobDetailModal.jsx
+++ b/client/src/components/JobDetailModal.jsx
@@ -300,27 +300,26 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
                         ? `PARTIAL - COLLECT $${amountDue.toFixed(2)}`
                         : `COLLECT $${amountDue.toFixed(2)}`}
                 </div>
-                <div className={`text-sm ${
-                  !requiresCollection
-                    ? 'text-green-700'
-                    : isFullyPaid
+                <div
+                  className={`text-sm ${
+                    !requiresCollection
                       ? 'text-green-700'
-                      : isPartiallyPaid
-                        ? 'text-yellow-700'
-                        : 'text-red-700'
-                }`}>
-                  {!requiresCollection ? (
-                    'No payment is required at delivery.'
-                  ) : (
-                    <>
-                      Total to collect: ${totalDue.toFixed(2)}
-                      {alreadyPaid > 0 && ` (${alreadyPaid.toFixed(2)} already received)`}
-                    </>
-                  )}
+                      : isFullyPaid
+                        ? 'text-green-700'
+                        : isPartiallyPaid
+                          ? 'text-yellow-700'
+                          : 'text-red-700'
+                  }`}
+                >
+                  {!requiresCollection
+                    ? 'No payment is required at delivery.'
+                    : alreadyPaid > 0
+                      ? `Payment received so far: $${alreadyPaid.toFixed(2)}`
+                      : 'Payment due upon delivery.'}
                 </div>
                 {(isOffice || isAdmin) && (
                   <div className="mt-4">
-                    {isEditing ? (
+                    {isEditing && (
                       <div>
                         <label className="block text-xs font-medium text-gray-700 mb-1 uppercase tracking-wide">
                           Amount to Collect
@@ -334,13 +333,6 @@ const JobDetailModal = ({ job, isOpen, onClose, onUpdate, drivers = [] }) => {
                           className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-eastmeadow-500"
                           placeholder="0.00"
                         />
-                      </div>
-                    ) : (
-                      <div className="text-sm text-gray-700">
-                        Amount to collect:{' '}
-                        <span className="font-semibold text-gray-900">
-                          {requiresCollection ? `$${totalDue.toFixed(2)}` : 'None'}
-                        </span>
                       </div>
                     )}
 

--- a/client/src/pages/AddJob.jsx
+++ b/client/src/pages/AddJob.jsx
@@ -431,8 +431,9 @@ const AddJob = () => {
                       value={formData.assigned_driver}
                       onChange={handleInputChange}
                       className="input-field"
+                      required={!toBeScheduled}
                     >
-                      <option value="">Select driver (optional)</option>
+                      <option value="">Select driver</option>
                       {drivers.map(driver => (
                         <option key={driver.id} value={driver.id}>
                           {driver.username}


### PR DESCRIPTION
## Summary
- streamline the delivery detail modal messaging by removing redundant collection amounts while retaining context for drivers and admins
- make driver assignment mandatory during job creation when a delivery date is set

## Testing
- npm run lint *(fails: ESLint configuration file is missing in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d56f57b8ac8330b125bca1f0286aab