### PR TITLE
Sort recent jobs by newest delivery date

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -50,8 +50,13 @@ const Dashboard = () => {
         }).length
       });
 
-      // Get recent jobs (last 5)
-      setRecentJobs(allJobs.slice(0, 5));
+      // Get recent jobs (last 5) sorted by most recent delivery date first
+      const sortedJobs = [...allJobs].sort((a, b) => {
+        const dateA = a?.delivery_date ? new Date(a.delivery_date) : new Date(0);
+        const dateB = b?.delivery_date ? new Date(b.delivery_date) : new Date(0);
+        return dateB - dateA;
+      });
+      setRecentJobs(sortedJobs.slice(0, 5));
     } catch (error) {
       console.error('Failed to fetch dashboard data:', error);
       // Set default stats if fetch fails


### PR DESCRIPTION
## Summary
- sort dashboard recent jobs list by delivery date so newest jobs appear first
- guard against missing delivery dates when ordering recent jobs

## Testing
- npm run lint *(fails: ESLint configuration file is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d5800be10483309cf656cc2abd6479